### PR TITLE
Modify GOPROXY to add Aliyun mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #Can change to a dockerhub mirror site like: FROM docker.1ms.run/alpine:latest
 FROM alpine:latest
 #Add a goproxy
-ENV GOPROXY "https://goproxy.cn"
+ENV GOPROXY "https://goproxy.cn,https://mirrors.aliyun.com/goproxy/,direct"
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 #Install Tailscale and requirements
 RUN apk add curl iptables


### PR DESCRIPTION
Updated GOPROXY environment variable to include additional mirrors.
goproxy.cn找不到最新的包，可以用阿里云的代理。

否则docker compose up -d  --build时，会报下面的错：

> RUN go install tailscale.com/cmd/derper@latest:
1.979 go: tailscale.com/cmd/derper@latest: module tailscale.com/cmd/derper: reading https://goproxy.cn/tailscale.com/cmd/derper/@v/list: 404 Not Found
1.979
server response: not found: bad upstream


